### PR TITLE
AREA-31 :sparkles: :green_heart: added workflow to launch and check health of docker compose

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -32,9 +32,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ hashFiles('**/Dockerfile') }}
           restore-keys: |
+            ${{ runner.os }}-buildx-${{ github.ref }}-
             ${{ runner.os }}-buildx-
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,50 @@
+name: Area
+
+on:
+  push:
+    branches-ignore:
+      - 'ga-ignore-**'
+  pull_request:
+    branches-ignore:
+      - 'ga-ignore-**'
+env:
+  MIRROR_URL: "git@github.com:EpitechPromo2027/B-DEV-500-NAN-5-2-area-toavina.andriamanampisoa.git"
+
+jobs:
+  check_health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start Docker Compose services
+        run: docker-compose up -d --build
+
+      - name: Check service health
+        uses: jaracogmbh/docker-compose-health-check-action@v1.0.0
+        with:
+          max-retries: 30
+          retry-interval: 5
+          compose-file: "docker-compose.yml"
+          skip-exited: "true"
+          skip-no-healthcheck: "true"
+
+      - name: Stop Docker Compose services
+        run: docker-compose down -v --remove-orphans
+
+  push_to_mirror:
+    runs-on: ubuntu-latest
+
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - name: Checkout fetch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url:
+            ${{ env.MIRROR_URL}}
+          ssh_private_key:
+            ${{ secrets.GIT_SSH_PRIVATE_KEY }}

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -16,14 +16,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Load environment variables
-        uses: cardinalby/export-env-action@v1
+      # Create .env file from Secret
+      - name: get environment variables
+        id: import-env
+        run: |
+          echo "${{ secrets.ENV_FILE }}" >> .env
+      - uses: cardinalby/export-env-action@v2
+        id: export-env
         with:
+          mask: true
           envFile: '.env'
-          expand: 'true'
+
+      # Remove .env file for security reasons
+      - name: remove .env file
+        run: rm -f .env
 
       - name: Start Docker Compose services
         run: docker compose up -d --build
+        env:
+          POSTGRES_DB: ${{ steps.export-env.outputs.POSTGRES_DB }}
+          POSTGRES_USER: ${{ steps.export-env.outputs.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ steps.export-env.outputs.POSTGRES_PASSWORD }}
+          EXPOSE_PORT_CLIENT: ${{ steps.export-env.outputs.EXPOSE_PORT_CLIENT }}
+          EXPOSE_PORT_SERVER: ${{ steps.export-env.outputs.EXPOSE_PORT_SERVER }}
 
       - name: Check service health
         uses: jaracogmbh/docker-compose-health-check-action@v1.0.0

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -58,6 +58,14 @@ jobs:
         if: failure()
         run: docker logs area-db-1
 
+      - name: Print area-server-1 logs
+        if: failure()
+        run: docker logs area-server-1
+
+      - name: Print area-client-web-1 logs
+        if: failure()
+        run: docker logs area-client-web-1
+
       - name: Stop Docker Compose services
         if: always()
         run: docker compose down -v --remove-orphans

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -81,21 +81,3 @@ jobs:
         if: always()
         run: docker compose down -v --remove-orphans
 
-  push_to_mirror:
-    needs: check_health
-    runs-on: ubuntu-latest
-
-    if: ${{ github.event_name == 'push' }}
-
-    steps:
-      - name: Checkout fetch
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: pixta-dev/repository-mirroring-action@v1
-        with:
-          target_repo_url:
-            ${{ env.MIRROR_URL}}
-          ssh_private_key:
-            ${{ secrets.GIT_SSH_PRIVATE_KEY }}

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -28,6 +28,16 @@ jobs:
           export: false
           envFile: '.env'
 
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Start Docker Compose services
         run: docker compose up -d --build
         continue-on-error: true

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Load environment variables
+        uses: cardinalby/export-env-action@v1
+        with:
+          envFile: '.env'
+          expand: 'true'
+
       - name: Start Docker Compose services
         run: docker compose up -d --build
 
@@ -30,7 +36,7 @@ jobs:
 
       - name: Stop Docker Compose services
         if: always()
-        run: docker-compose down -v --remove-orphans
+        run: docker compose down -v --remove-orphans
       - name: Print Docker Compose logs
         if: failure()
         run: docker compose logs

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: get environment variables
         id: import-env
         run: |
-          echo "${{ secrets.ENV_FILE }}"
           echo "${{ secrets.ENV_FILE }}" >> .env
+          cat .env
       - uses: cardinalby/export-env-action@v2
         id: exportEnv
         with:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -49,9 +49,6 @@ jobs:
           skip-exited: "true"
           skip-no-healthcheck: "true"
 
-      - name: Stop Docker Compose services
-        if: always()
-        run: docker compose down -v --remove-orphans
       - name: Print Docker Compose logs
         if: failure()
         run: docker compose logs
@@ -59,6 +56,10 @@ jobs:
       - name: Print area-db-1 logs
         if: failure()
         run: docker logs area-db-1
+
+      - name: Stop Docker Compose services
+        if: always()
+        run: docker compose down -v --remove-orphans
 
   push_to_mirror:
     needs: check_health

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Start Docker Compose services
         run: docker compose up -d --build
+        continue-on-error: true
         env:
           POSTGRES_DB: ${{ steps.exportEnv.outputs.POSTGRES_DB }}
           POSTGRES_USER: ${{ steps.exportEnv.outputs.POSTGRES_USER }}

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -22,19 +22,20 @@ jobs:
         run: |
           echo "${{ secrets.ENV_FILE }}" >> .env
       - uses: cardinalby/export-env-action@v2
-        id: export-env
+        id: exportEnv
         with:
           mask: true
+          export: false
           envFile: '.env'
 
       - name: Start Docker Compose services
         run: docker compose up -d --build
         env:
-          POSTGRES_DB: ${{ steps.export-env.outputs.POSTGRES_DB }}
-          POSTGRES_USER: ${{ steps.export-env.outputs.POSTGRES_USER }}
-          POSTGRES_PASSWORD: ${{ steps.export-env.outputs.POSTGRES_PASSWORD }}
-          EXPOSE_PORT_CLIENT: ${{ steps.export-env.outputs.EXPOSE_PORT_CLIENT }}
-          EXPOSE_PORT_SERVER: ${{ steps.export-env.outputs.EXPOSE_PORT_SERVER }}
+          POSTGRES_DB: ${{ steps.exportEnv.outputs.POSTGRES_DB }}
+          POSTGRES_USER: ${{ steps.exportEnv.outputs.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ steps.exportEnv.outputs.POSTGRES_PASSWORD }}
+          EXPOSE_PORT_CLIENT: ${{ steps.exportEnv.outputs.EXPOSE_PORT_CLIENT }}
+          EXPOSE_PORT_SERVER: ${{ steps.exportEnv.outputs.EXPOSE_PORT_SERVER }}
 
       # Remove .env file for security reasons
       - name: remove .env file

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -29,7 +29,15 @@ jobs:
           skip-no-healthcheck: "true"
 
       - name: Stop Docker Compose services
+        if: always()
         run: docker-compose down -v --remove-orphans
+      - name: Print Docker Compose logs
+        if: failure()
+        run: docker compose logs
+
+      - name: Print area-db-1 logs
+        if: failure()
+        run: docker logs area-db-1
 
   push_to_mirror:
     needs: check_health

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -21,7 +21,6 @@ jobs:
         id: import-env
         run: |
           echo "${{ secrets.ENV_FILE }}" >> .env
-          cat .env
       - uses: cardinalby/export-env-action@v2
         id: exportEnv
         with:
@@ -46,7 +45,7 @@ jobs:
       - name: Check service health
         uses: jaracogmbh/docker-compose-health-check-action@v1.0.0
         with:
-          max-retries: 30
+          max-retries: 10
           retry-interval: 5
           compose-file: "docker-compose.yml"
           skip-exited: "true"

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -27,10 +27,6 @@ jobs:
           mask: true
           envFile: '.env'
 
-      # Remove .env file for security reasons
-      - name: remove .env file
-        run: rm -f .env
-
       - name: Start Docker Compose services
         run: docker compose up -d --build
         env:
@@ -39,6 +35,10 @@ jobs:
           POSTGRES_PASSWORD: ${{ steps.export-env.outputs.POSTGRES_PASSWORD }}
           EXPOSE_PORT_CLIENT: ${{ steps.export-env.outputs.EXPOSE_PORT_CLIENT }}
           EXPOSE_PORT_SERVER: ${{ steps.export-env.outputs.EXPOSE_PORT_SERVER }}
+
+      # Remove .env file for security reasons
+      - name: remove .env file
+        run: rm -f .env
 
       - name: Check service health
         uses: jaracogmbh/docker-compose-health-check-action@v1.0.0

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -52,7 +52,7 @@ jobs:
       #   uses: docker/setup-buildx-action@v2
 
       - name: Start Docker Compose services
-        run: docker compose up -d --build
+        run: docker compose up -d
         continue-on-error: true
         env:
           POSTGRES_DB: ${{ steps.exportEnv.outputs.POSTGRES_DB }}

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -14,7 +14,8 @@ jobs:
   check_health:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
 
       # Create .env file from Secret
       - name: get environment variables
@@ -28,17 +29,26 @@ jobs:
           export: false
           envFile: '.env'
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.ref }}-
-            ${{ runner.os }}-buildx-
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - name: Build docker containers
+        uses: docker/bake-action@v3
+        with:
+          files: docker-bake.hcl
+          load: true
+
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ hashFiles('**/Dockerfile') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildx-${{ github.ref }}-
+      #       ${{ runner.os }}-buildx-
+
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
 
       - name: Start Docker Compose services
         run: docker compose up -d --build

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Print area-client_web-1 logs
         if: failure()
-        run: docker logs area-client-web-1
+        run: docker logs area-client_web-1
 
       - name: Stop Docker Compose services
         if: always()

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -32,6 +32,7 @@ jobs:
         run: docker-compose down -v --remove-orphans
 
   push_to_mirror:
+    needs: check_health
     runs-on: ubuntu-latest
 
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -62,7 +62,7 @@ jobs:
         if: failure()
         run: docker logs area-server-1
 
-      - name: Print area-client-web-1 logs
+      - name: Print area-client_web-1 logs
         if: failure()
         run: docker logs area-client-web-1
 

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Start Docker Compose services
-        run: docker-compose up -d --build
+        run: docker compose up -d --build
 
       - name: Check service health
         uses: jaracogmbh/docker-compose-health-check-action@v1.0.0

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: docker/bake-action@v3
         with:
           files: docker-bake.hcl
+          targets: default
           load: true
 
       # - name: Cache Docker layers

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -32,24 +32,16 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
 
+      # bake action is used to build the docker containers from the docker-bake.hcl file
+      # The docker-bake.hcl file is used to define the build targets for the docker containers
+      # it is used to build the docker containers in parallel to save time
+      # then when we'll run the docker compose up command, the containers will be already built
       - name: Build docker containers
         uses: docker/bake-action@v3
         with:
           files: docker-bake.hcl
           targets: default
           load: true
-
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /tmp/.buildx-cache
-      #     key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ hashFiles('**/Dockerfile') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-buildx-${{ github.ref }}-
-      #       ${{ runner.os }}-buildx-
-
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v2
 
       - name: Start Docker Compose services
         run: docker compose up -d

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: get environment variables
         id: import-env
         run: |
+          echo "${{ secrets.ENV_FILE }}"
           echo "${{ secrets.ENV_FILE }}" >> .env
       - uses: cardinalby/export-env-action@v2
         id: exportEnv

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,1 +1,11 @@
-FROM ubuntu
+FROM node:20
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm i
+
+EXPOSE $PORT
+
+CMD ["npm", "run", "serve"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,6 +6,6 @@ COPY . .
 
 RUN npm i
 
-EXPOSE $PORT
+EXPOSE 80
 
 CMD ["npm", "run", "serve"]

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -1,4 +1,7 @@
 const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
-  transpileDependencies: true
+  transpileDependencies: true,
+  devServer: {
+    port: 80,
+  }
 })

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,40 @@
+target "client_web" {
+  cache-to = [
+    "type=gha,ignore-error=true,mode=max,scope=client_web"
+  ]
+  cache-from = [
+    "type=gha,scope=client_web"
+  ]
+}
+target "server" {
+  cache-to = [
+    "type=gha,ignore-error=true,mode=max,scope=server"
+  ]
+  cache-from = [
+    "type=gha,scope=server"
+  ]
+}
+target "db" {
+  cache-to = [
+    "type=gha,ignore-error=true,mode=max,scope=db"
+  ]
+  cache-from = [
+    "type=gha,scope=db"
+  ]
+}
+target "client_mobile" {
+  cache-to = [
+    "type=gha,ignore-error=true,mode=max,scope=client_mobile"
+  ]
+  cache-from = [
+    "type=gha,scope=client_mobile"
+  ]
+}
+target "service-about" {
+  cache-to = [
+    "type=gha,ignore-error=true,mode=max,scope=service-about"
+  ]
+  cache-from = [
+    "type=gha,scope=service-about"
+  ]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,16 +18,6 @@ target "server" {
     "type=gha,scope=server"
   ]
 }
-target "db" {
-  context = "."
-  dockerfile = "Dockerfile"
-  cache-to = [
-    "type=gha,ignore-error=true,mode=max,scope=db"
-  ]
-  cache-from = [
-    "type=gha,scope=db"
-  ]
-}
 target "client_mobile" {
   context = "./mobile"
   dockerfile = "Dockerfile"
@@ -49,5 +39,5 @@ target "service-about" {
   ]
 }
 group "default" {
-  targets = ["client_web", "server", "db", "client_mobile", "service-about"]
+  targets = ["client_web", "server", "client_mobile", "service-about"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -38,3 +38,6 @@ target "service-about" {
     "type=gha,scope=service-about"
   ]
 }
+group "default" {
+  targets = ["client_web", "server", "db", "client_mobile", "service-about"]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,4 +1,6 @@
 target "client_web" {
+  context = "./client"
+  dockerfile = "Dockerfile"
   cache-to = [
     "type=gha,ignore-error=true,mode=max,scope=client_web"
   ]
@@ -7,6 +9,8 @@ target "client_web" {
   ]
 }
 target "server" {
+  context = "./services/router"
+  dockerfile = "Dockerfile"
   cache-to = [
     "type=gha,ignore-error=true,mode=max,scope=server"
   ]
@@ -15,6 +19,8 @@ target "server" {
   ]
 }
 target "db" {
+  context = "."
+  dockerfile = "Dockerfile"
   cache-to = [
     "type=gha,ignore-error=true,mode=max,scope=db"
   ]
@@ -23,6 +29,8 @@ target "db" {
   ]
 }
 target "client_mobile" {
+  context = "./mobile"
+  dockerfile = "Dockerfile"
   cache-to = [
     "type=gha,ignore-error=true,mode=max,scope=client_mobile"
   ]
@@ -31,6 +39,8 @@ target "client_mobile" {
   ]
 }
 target "service-about" {
+  context = "./services/about"
+  dockerfile = "Dockerfile"
   cache-to = [
     "type=gha,ignore-error=true,mode=max,scope=service-about"
   ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   client_web:
     build:
@@ -8,13 +6,19 @@ services:
     ports:
       - "${EXPOSE_PORT_CLIENT}:80"
     restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:80"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   client_mobile:
     build:
       context: ./mobile
       dockerfile: Dockerfile
     depends_on:
-      - client_web
+      client_web:
+        condition: service_healthy
     restart: on-failure
 
   server:
@@ -28,6 +32,11 @@ services:
         condition: service_healthy
     networks:
       - server-tier
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:80"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   service-about:
     build:
@@ -50,7 +59,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/services/router/Dockerfile
+++ b/services/router/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN cargo install --path .
 
 FROM debian:bullseye-slim
-RUN apt-get update && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/router /usr/local/bin/router
 
 EXPOSE 80

--- a/services/router/src/main.rs
+++ b/services/router/src/main.rs
@@ -23,6 +23,8 @@ fn main()
 {
     let listener = TcpListener::bind("0.0.0.0:80").unwrap();
 
+    println!("Server started at port 80");
+
     for stream in listener.incoming() {
         let stream = stream.unwrap();
 


### PR DESCRIPTION
This PR adds the following features :

- New Dockerfile in `client` folder to launch the frontend using Docker
- Added health check rules in `docker-compose.yml` to ensure all containers are healthy and accepting requests
- added Github Actions CI build. This build will:
    - 1. Check out the repository (get access to the code part)
    - 2. Get the environment variables that should be in `.env`, but not in repository. To access these vars, I created a repository secret containing all needed variables to launch all docker images. All these vars are default vars.
    - 3. Set up docker environment using `bake`. It reads a config file that contains all docker images, will then builds them. It permits to cache them to save time for each CI.
    - 4. Start all containers previously built in `c.`.
    - 5. Check every health state for every images running.
    - 6. print logs for images that failed (ONLY when error).
    - 7. Clear docker compose.

Linked to [This issue](https://epitech-area-last-chance.atlassian.net/jira/software/projects/AREA/boards/1?selectedIssue=AREA-31)