### PR TITLE
AREA-6 :green_heart: added `push_to_mirror` rule in CI

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -86,3 +86,22 @@ jobs:
         if: always()
         run: docker compose down -v --remove-orphans
 
+  push_to_mirror:
+    runs-on: ubuntu-latest
+    needs:
+      - check_health
+
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url:
+            ${{ env.MIRROR_URL}}
+          ssh_private_key:
+            ${{ secrets.GIT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
This PR adds the following features :

- New service in Github Actions CI : `push_to_mirror`. This service (or rule) needs the needed rule (in this case, `check_health`) to succeed. If yes, it will push all the code of this repository in another distant repository, using his URL and key in `secrets`. 

Linked to [This issue](https://epitech-area-last-chance.atlassian.net/jira/software/projects/AREA/boards/1?selectedIssue=AREA-6)