### PR TITLE
AREA-69 :sparkles: linked backend auth service with frontend auth pages

### DIFF
--- a/client/axios.js
+++ b/client/axios.js
@@ -1,9 +1,17 @@
-import axios from 'axios';
+import axios from 'axios'
 
-const axiosInstance = axios.create({
-  baseURL: 'http://localhost:8000/api/',
-  timeout: 1000,
-  headers: {'Content-Type': 'application/json'}
-});
+class AxiosOptions {
+    baseUrl
+    token
+}
 
-export default axiosInstance;
+export default {
+    install: (app, options) => {
+        app.config.globalProperties.$axios = axios.create({
+            baseURL: options.baseUrl,
+            headers: {
+                Authorization: options.token ? `Bearer ${options.token}` : '',
+            }
+        })
+    }
+}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2,5 +2,8 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
+import axios from '../axios';
 
-createApp(App).use(store).use(router).mount('#app')
+createApp(App).use(store).use(router).use(axios, {
+    baseUrl: 'http://localhost:8080',
+}).mount('#app')

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -67,6 +67,10 @@ export default {
             event.preventDefault()
             window.location.href = this.$router.resolve({ name: 'register' }).href;
         },
+        navigateToHome(event) {
+            event.preventDefault()
+            window.location.href = this.$router.resolve({ name: 'home' }).href;
+        },
         checkScreen() {
             this.windowWidth = window.innerWidth;
             if (this.windowWidth <= 960) {
@@ -75,7 +79,7 @@ export default {
                 this.mobile = false;
             }
         },
-        async loginClient() {
+        async loginClient(event) {
             if (!this.email || !this.password) {
                 this.errorMessage = 'Please fill all the fields';
                 return;
@@ -90,14 +94,14 @@ export default {
                     Email: this.email,
                     Password: this.password
                 });
-                const data = await response.json();
-                if (data.error) {
-                    this.errorMessage = data.error;
+                if (!response.data || !response.data.responses || response.data.responses.length === 0) {
+                    this.errorMessage = 'Invalid email or password';
                     return;
                 }
-                console.log(data);
-                localStorage.setItem('token', data.token);
-                this.$router.push({ name: 'home' });
+                const token = response.data.responses[0];
+                console.log(token);
+                localStorage.setItem('token', token);
+                this.navigateToHome(event);
             } catch (error) {
                 console.error(error);
                 this.errorMessage = 'An error occurred';

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -9,13 +9,16 @@
             <div class="main-container-bottom">
                 <div class="email-container">
                     <img src="@/assets/user.png" class="img-style1">
-                    <input type="text" class="input-style1" placeholder="Email">
+                    <input type="text" class="input-style1" placeholder="Email" v-model="email">
                 </div>
                 <div class="pwd-container">
                     <img src="@/assets/key.png" class="img-style1">
-                    <input type="password" class="input-style1" placeholder="Password">
+                    <input type="password" class="input-style1" placeholder="Password" v-model="password">
                 </div>
                 <button @click="loginClient" class="login-btn">LOGIN</button>
+                <div v-if="errorMessage" class="error-message">
+                    <span>{{ errorMessage }}</span>
+                </div>
                 <div class="or-filler">
                     <hr class="or-hr">
                     <p class="or-txt">or</p>
@@ -50,6 +53,9 @@ export default {
         return {
             windowWidth: false,
             mobile: false,
+            email: '',
+            password: '',
+            errorMessage: ''
         }
     },
     mounted() {
@@ -70,7 +76,32 @@ export default {
             }
         },
         async loginClient() {
-            // Login client
+            if (!this.email || !this.password) {
+                this.errorMessage = 'Please fill all the fields';
+                return;
+            }
+            if (!this.email.includes('@') || !this.email.includes('.')) {
+                this.errorMessage = 'Please enter a valid email';
+                return;
+            }
+            this.errorMessage = '';
+            try {
+                const response = await this.$axios.post('/auth/login', {
+                    Email: this.email,
+                    Password: this.password
+                });
+                const data = await response.json();
+                if (data.error) {
+                    this.errorMessage = data.error;
+                    return;
+                }
+                console.log(data);
+                localStorage.setItem('token', data.token);
+                this.$router.push({ name: 'home' });
+            } catch (error) {
+                console.error(error);
+                this.errorMessage = 'An error occurred';
+            }
         }
     }
 }
@@ -346,6 +377,13 @@ body {
     cursor: pointer;
     margin: 0;
     padding: 0;
+}
+
+.error-message {
+    color: red;
+    font-family: 'inter', sans-serif;
+    font-size: medium;
+    margin-bottom: -1rem;
 }
 
 </style>

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -7,15 +7,22 @@
                 <img src="@/assets/logo.png" class="logo">
             </div>
             <div class="main-container-bottom">
+                <div class="username-container">
+                    <img src="@/assets/user.png" class="img-style1">
+                    <input type="text" class="input-style1" placeholder="Name" v-model="name">
+                </div>
                 <div class="email-container">
                     <img src="@/assets/user.png" class="img-style1">
-                    <input type="text" class="input-style1" placeholder="Email">
+                    <input type="text" class="input-style1" placeholder="Your Email" v-model="email">
                 </div>
                 <div class="pwd-container">
                     <img src="@/assets/key.png" class="img-style1">
-                    <input type="password" class="input-style1" placeholder="Password">
+                    <input type="password" class="input-style1" placeholder="Your Password" v-model="password">
                 </div>
                 <button @click="registerClient" class="login-btn">REGISTER</button>
+                <div v-if="errorMessage" class="error-message">
+                    <span>{{ errorMessage }}</span>
+                </div>
                 <div class="filler02"></div>
                 <router-link class="link"><h4 class="txt-link" @click="navigateToLogin">Already have an account ?</h4></router-link>
             </div>
@@ -31,6 +38,10 @@ export default {
         return {
             windowWidth: false,
             mobile: false,
+            email: '',
+            password: '',
+            name: '',
+            errorMessage: ''
         }
     },
     mounted() {
@@ -51,8 +62,35 @@ export default {
             }
         },
         async registerClient() {
-            // Register client
-        }
+            if (!this.email || !this.password) {
+                this.errorMessage = 'Please fill in all fields';
+                return;
+            }
+            // check if email is valid
+            if (!this.email.includes('@') || !this.email.includes('.')) {
+                this.errorMessage = 'Please enter a valid email address';
+                return;
+            }
+
+            this.errorMessage = '';
+
+            try {
+                console.log('Registering client...');
+                const response = await this.$axios.post('/auth/register', {
+                    Email: this.email,
+                    Password: this.password,
+                    ConfirmedPassword: this.password,
+                    Username: this.name
+                });
+                console.log(response);
+
+                // Redirect to login page
+                this.$router.push({ name: 'login' });
+            } catch (error) {
+                console.error(error);
+                this.errorMessage = 'An error occurred. Please try again later.';
+            };
+        },
     }
 }
 </script>
@@ -144,6 +182,15 @@ body {
     background-color: transparent;
 }
 
+.username-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: transparent;
+    height: 3rem;
+    width: 23rem;
+}
+
 .email-container {
     display: flex;
     flex-direction: row;
@@ -213,7 +260,7 @@ body {
     font-weight: 600;
     cursor: pointer;
     margin-top: 0.5rem;
-    margin-bottom: 1rem;
+    margin-bottom: 5px;
 }
 
 .login-btn:hover {
@@ -333,6 +380,13 @@ body {
     cursor: pointer;
     margin: 0;
     padding: 0;
+}
+
+.error-message {
+    color: red;
+    font-family: 'inter', sans-serif;
+    font-size: medium;
+    margin-bottom: -2rem;
 }
 
 </style>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "${EXPOSE_PORT_CLIENT}:80"
+    environment:
+      - EXPOSE_PORT_SERVER=${EXPOSE_PORT_SERVER}
     restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:80"]
@@ -33,8 +35,12 @@ services:
     build:
       context: ./services/advanced
       dockerfile: Dockerfile
+    ports:
+      - "5000:8080"
     depends_on:
       db:
+        condition: service_healthy
+      server:
         condition: service_healthy
     networks:
       - server-tier

--- a/services/advanced/AdvancedServices/Program.cs
+++ b/services/advanced/AdvancedServices/Program.cs
@@ -72,6 +72,7 @@ public static class Program
             await context.Database.MigrateAsync();
         }
 
+        app.UseMiddleware<ResponseBufferingMiddleware>();
         app.UseRouting();
         app.UseCors("AllowAll");
         app.UseAuthentication();

--- a/services/advanced/AdvancedServices/ResponseBufferingMiddleware.cs
+++ b/services/advanced/AdvancedServices/ResponseBufferingMiddleware.cs
@@ -1,0 +1,39 @@
+﻿public class ResponseBufferingMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public ResponseBufferingMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var originalBodyStream = context.Response.Body;
+
+        using (var memoryStream = new MemoryStream())
+        {
+            context.Response.Body = memoryStream;
+
+            try
+            {
+                await _next(context);
+
+                memoryStream.Position = 0;
+
+                var responseBody = await new StreamReader(memoryStream).ReadToEndAsync();
+
+                context.Response.ContentLength = responseBody.Length;
+
+                memoryStream.Position = 0;
+
+                await memoryStream.CopyToAsync(originalBodyStream);
+            }
+            catch
+            {
+                context.Response.Body = originalBodyStream;
+                throw;
+            }
+        }
+    }
+}

--- a/services/router/routes.yml
+++ b/services/router/routes.yml
@@ -1,10 +1,10 @@
 routes:
   - name: auth-login
     host: csharp_service
-    port: 5000
+    port: 8080
     condition: ^/auth/login$
 
   - name: auth-register
     host: csharp_service
-    port: 5000
+    port: 8080
     condition: ^/auth/register$

--- a/services/router/src/main.rs
+++ b/services/router/src/main.rs
@@ -19,12 +19,10 @@ fn handle_connection(mut stream: TcpStream) {
     let mut req = parser::collect_request(&stream);
     let mut response = Response::new();
 
-    response.headers.insert("Access-Control-Allow-Origin".to_string(), "*".to_string());
-    response.headers.insert("Access-Control-Allow-Methods".to_string(), "GET, POST, PUT, DELETE, OPTIONS".to_string());
-    response.headers.insert("Access-Control-Allow-Headers".to_string(), "Content-Type, Authorization".to_string());
-    response.headers.insert("Access-Control-Allow-Credentials".to_string(), "true".to_string());
-
     if req.method == "OPTIONS" {
+        response.headers.insert("Access-Control-Allow-Origin".to_string(), "*".to_string());
+        response.headers.insert("Access-Control-Allow-Headers".to_string(), "Content-Type, Authorization".to_string());
+
         response.code = 204;
         response.message = String::from("No Content");
         stream.write_all(&response.build_request()).unwrap();
@@ -43,11 +41,6 @@ fn handle_connection(mut stream: TcpStream) {
 
                     let mut res = parser::collect_response(&socket);
 
-                    response.headers.insert("Access-Control-Allow-Origin".to_string(), "*".to_string());
-                    response.headers.insert("Access-Control-Allow-Methods".to_string(), "GET, POST, PUT, DELETE, OPTIONS".to_string());
-                    response.headers.insert("Access-Control-Allow-Headers".to_string(), "Content-Type, Authorization".to_string());
-
-                    eprintln!("{} - {} - {}", req.method, req.route, res.code);
                     stream.write_all(&res.build_request()).unwrap();
                     return ();
                 }

--- a/services/router/src/main.rs
+++ b/services/router/src/main.rs
@@ -22,6 +22,7 @@ fn handle_connection(mut stream: TcpStream) {
     response.headers.insert("Access-Control-Allow-Origin".to_string(), "*".to_string());
     response.headers.insert("Access-Control-Allow-Methods".to_string(), "GET, POST, PUT, DELETE, OPTIONS".to_string());
     response.headers.insert("Access-Control-Allow-Headers".to_string(), "Content-Type, Authorization".to_string());
+    response.headers.insert("Access-Control-Allow-Credentials".to_string(), "true".to_string());
 
     if req.method == "OPTIONS" {
         response.code = 204;

--- a/services/router/src/main.rs
+++ b/services/router/src/main.rs
@@ -15,51 +15,41 @@ use response::Response;
 use routes::RouteLoader;
 
 fn handle_connection(mut stream: TcpStream) {
-    static CELL: OnceLock<Mutex<RouteLoader>> = OnceLock::new();
+    static CELL: OnceLock<Mutex<RouteLoader>> =  OnceLock::new();
     let mut req = parser::collect_request(&stream);
     let mut response = Response::new();
+
+    response.headers.insert("Access-Control-Allow-Origin".to_string(), "*".to_string());
+    response.headers.insert("Access-Control-Allow-Methods".to_string(), "GET, POST, PUT, DELETE, OPTIONS".to_string());
+    response.headers.insert("Access-Control-Allow-Headers".to_string(), "Content-Type, Authorization".to_string());
+    response.headers.insert("Access-Control-Allow-Credentials".to_string(), "true".to_string());
 
     if req.method == "OPTIONS" {
         response.code = 204;
         response.message = String::from("No Content");
-        response.headers.insert("Access-Control-Allow-Origin".to_string(), "*".to_string());
-        response.headers.insert("Access-Control-Allow-Methods".to_string(), "GET, POST, PUT, DELETE, OPTIONS".to_string());
-        
-        if let Some(requested_headers) = req.headers.get("access-control-request-headers") {
-            response.headers.insert(
-                "Access-Control-Allow-Headers".to_string(),
-                requested_headers.clone(),
-            );
-        } else {
-            response.headers.insert(
-                "Access-Control-Allow-Headers".to_string(),
-                "*".to_string(),
-            );
-        }
-    
-        response.headers.insert("Access-Control-Allow-Credentials".to_string(), "true".to_string());
         stream.write_all(&response.build_request()).unwrap();
         return;
-    }    
+    }
 
     let router = CELL.get_or_init(|| Mutex::new(RouteLoader::new("routes.yml")));
 
     match router.lock().unwrap().get_route(&req.route) {
         Some(&ref route) => {
-            let ip_lookup = format!("{}:{}", route.host, route.port)
-                .to_socket_addrs()
-                .expect("failed to connect to service")
-                .next()
-                .unwrap();
+            let ip_lookup = format!("{}:{}", route.host, route.port).to_socket_addrs().expect("failed to connect to service").next().unwrap();
 
-            match TcpStream::connect_timeout(&ip_lookup, Duration::from_secs(10)) {
+            match TcpStream::connect_timeout(&ip_lookup, Duration::from_millis(1024 * 10)) {
                 Ok(mut socket) => {
                     socket.write_all(&req.build_request()).unwrap();
 
                     let mut res = parser::collect_response(&socket);
 
+                    response.headers.insert("Access-Control-Allow-Origin".to_string(), "*".to_string());
+                    response.headers.insert("Access-Control-Allow-Methods".to_string(), "GET, POST, PUT, DELETE, OPTIONS".to_string());
+                    response.headers.insert("Access-Control-Allow-Headers".to_string(), "Content-Type, Authorization".to_string());
+
+                    eprintln!("{} - {} - {}", req.method, req.route, res.code);
                     stream.write_all(&res.build_request()).unwrap();
-                    return;
+                    return ();
                 }
                 Err(e) => {
                     eprintln!("Failed to connect to service at {}: {}: {}", route.host, route.port, e);
@@ -70,22 +60,22 @@ fn handle_connection(mut stream: TcpStream) {
                     stream.write_all(&response.build_request()).unwrap();
                 }
             }
-        }
-        None => {
+        },
+        _ => {
             if req.route == "/health" {
                 response.set_body("OK");
                 response.code = 200;
                 response.message = String::from("OK");
 
                 stream.write_all(&response.build_request()).unwrap();
-                return;
+                return ();
             }
-            response.set_body("Not Found");
+            response.set_body("Not found");
             response.code = 404;
             response.message = String::from("NOT FOUND");
 
             stream.write_all(&response.build_request()).unwrap();
-        }
+        },
     }
 }
 


### PR DESCRIPTION
This PR add/fix the following :

- Fixed CORS usage to enable communication between backend and frontend
- Added login route in frontend to use backend
- Added register route in frontend to use backend
- Added new middleware in `csharp_service` to get length of the response

To do :
Link the service page (in progress) with backend